### PR TITLE
fix grok 3 and grok 3 mini benchmark results

### DIFF
--- a/models/xai/grok-3-mini/model.json
+++ b/models/xai/grok-3-mini/model.json
@@ -21,7 +21,7 @@
   "qualitative_metrics": [
     {
       "dataset_name": "GPQA",
-      "score": 0.846,
+      "score": 0.84,
       "is_self_reported": true,
       "analysis_method": "accuracy",
       "date_recorded": "2025-02-24",
@@ -29,7 +29,7 @@
     },
     {
       "dataset_name": "LiveCodeBench",
-      "score": 0.8,
+      "score": 0.804,
       "is_self_reported": true,
       "analysis_method": "accuracy",
       "date_recorded": "2025-02-24",
@@ -45,7 +45,7 @@
     },
     {
       "dataset_name": "AIME 2025",
-      "score": 0.903,
+      "score": 0.908,
       "is_self_reported": true,
       "analysis_method": "accuracy",
       "date_recorded": "2025-02-24",

--- a/models/xai/grok-3/model.json
+++ b/models/xai/grok-3/model.json
@@ -29,7 +29,7 @@
     },
     {
       "dataset_name": "LiveCodeBench",
-      "score": 0.79,
+      "score": 0.794,
       "is_self_reported": true,
       "analysis_method": "accuracy",
       "date_recorded": "2025-02-24",
@@ -37,7 +37,7 @@
     },
     {
       "dataset_name": "AIME 2024",
-      "score": 0.93,
+      "score": 0.933,
       "is_self_reported": true,
       "analysis_method": "accuracy",
       "date_recorded": "2025-02-24",
@@ -45,7 +45,7 @@
     },
     {
       "dataset_name": "AIME 2025",
-      "score": 0.93,
+      "score": 0.933,
       "is_self_reported": true,
       "analysis_method": "accuracy",
       "date_recorded": "2025-02-24",


### PR DESCRIPTION
## Description

fixes inconsistencies between grok 3 and grok 3 mini benchmark results. fixes https://github.com/JonathanChavezTamales/llm-leaderboard/issues/60

<!-- Mark the appropriate option with an [x] -->

- [ ] Model Update/Addition
- [x] Qualitative Metrics (Benchmark Results) Update/Addition
- [ ] Provider Update/Addition
- [ ] Other (please specify)

## Checklist

- [x] I've read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My changes are accurate and properly referenced
